### PR TITLE
Add missing fields to desktop struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add CHANGELOG file for tracking relevant user-facing changes
 
+### Fixed
+
+- Fix `border_width` and `focused_node_id` fields missing in `Desktop` struct

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -69,6 +69,8 @@ pub struct Desktop {
     pub layout: Layout,
     pub user_layout: Layout,
     pub window_gap: i32,
+    pub border_width: i32,
+    pub focused_node_id: Id,
     pub padding: Padding,
     pub root: Option<Node>,
 }


### PR DESCRIPTION
Added `border_width` and `focused_node_id` fields to `Desktop` struct